### PR TITLE
Fix wording

### DIFF
--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -28,7 +28,7 @@
 		"message": "Sofort Liken"
 	},
 	"optLikeCustom": {
-		"message": "Benutzerdefinierte Wartezeit"
+		"message": "Benutzerdefiniert"
 	},
 	"optLikePercentage": {
 		"message": "Prozent"


### PR DESCRIPTION
Noticed that the custom group allows for more than just time based settings and the previous translation was more directed towards time, now its more generic and fits better.
