### PR TITLE
Get new youtube subscribe button

### DIFF
--- a/app/scripts/modules/liker-material.js
+++ b/app/scripts/modules/liker-material.js
@@ -324,6 +324,12 @@ class MaterialLiker {
 		let subscribeButton = document.querySelector(
 			'ytd-subscribe-button-renderer > paper-button, ytg-subscribe-button > paper-button, ytd-subscribe-button-renderer > .ytd-subscribe-button-renderer'
 		);
+		// if new youtube 06/2022
+		if (subscribeButton.hasAttribute("hidden")) {
+			subscribeButton = document.querySelector(
+				'ytd-subscribe-button-renderer > tp-yt-paper-button.ytd-subscribe-button-renderer'
+			)
+		}
 		return subscribeButton && (subscribeButton.hasAttribute('subscribed') ||
 			subscribeButton.getAttribute("aria-pressed") === "true");
 	}	


### PR DESCRIPTION
Fixes #63 

## Proposed Changes
The old button is still present, but is deactivated with the `hidden`attribute. If, hidden , select the new youtube button.